### PR TITLE
Fix week number calculator, to meet ISO 8601 standard.

### DIFF
--- a/date.format.js
+++ b/date.format.js
@@ -17,7 +17,17 @@
         w: function() { return this.getDay(); },
         z: function() { var d = new Date(this.getFullYear(),0,1); return Math.ceil((this - d) / 86400000); }, // Fixed now
         // Week
-        W: function() { var d = new Date(this.getFullYear(), 0, 1); return Math.ceil((((this - d) / 86400000) + d.getDay() + 1) / 7); }, // Fixed now
+        W: function() { 
+            var target = new Date(this.valueOf());
+            var dayNr = (this.getDay() + 6) % 7;
+            target.setDate(target.getDate() - dayNr + 3);
+            var firstThursday = target.valueOf();
+            target.setMonth(0, 1);
+            if (target.getDay() !== 4) {
+                target.setMonth(0, 1 + ((4 - target.getDay()) + 7) % 7);
+            }
+            return 1 + Math.ceil((firstThursday - target) / 604800000);
+        },
         // Month
         F: function() { return Date.longMonths[this.getMonth()]; },
         m: function() { return (this.getMonth() < 9 ? '0' : '') + (this.getMonth() + 1); },


### PR DESCRIPTION
It should fix issue #6, I reused the code from webpage: http://techblog.procurios.nl/k/news/view/33796/14863/calculate-iso-8601-week-and-year-in-javascript.html
